### PR TITLE
Fix imports

### DIFF
--- a/ttws/cli.py
+++ b/ttws/cli.py
@@ -1,8 +1,9 @@
 import sys
 import os
 import getopt
+import textwrap
 
-from . import extstring, textwrap, detecttype
+from . import *
 
 
 def main(args=None):


### PR DESCRIPTION
This is how I run it

``` python
Python 2.7.6 (default, Nov 10 2013, 19:24:24) [MSC v.1500 64 bit (AMD64)] on win32
Type "copyright", "credits" or "license()" for more information.
>>> import ttws.cli
>>> ttws.cli.main([r'c:\Python27\Scripts\ttws-script.py', '-c', r'c:\Projects\PlanarMechanics'])
```
