### PR TITLE
Fixes #9 by introducing a new --eol option to force a line ending type

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ You can find the latest stable releases under the
             Force the line endings to be of type:
             - CRLF = '\r\n' Windows
             - LF = '\n' POSIX
-            - CR = '\r' Mac
+            - CR = '\\r' Mac (pre OSX)
+            If empty or not specified it is set to the OS default.
 
         -c, --clean
             WARNING: USE THIS OPTION AT YOUR OWN RISK AS IT *WILL* BREAK YOUR CODE!

--- a/ttws/__init__.py
+++ b/ttws/__init__.py
@@ -79,12 +79,11 @@ def detecttype(filepath):
 
 def trimWhitespace(filepath, eol):
     """Trim trailing white spaces from a given filepath."""
-    lines = []
-    with io.open(filepath, "r") as f:
-        for line in f:
-            lines.append(line.rstrip())
-    with io.open(filepath, "w", newline=eol) as f:
-        f.write("\n".join(lines) + "\n")
+    with io.open(filepath, "r") as source:
+        for line in source:
+            lines = [line.rstrip() for line in source]
+    with io.open(filepath, "w", newline=eol) as target:
+        target.write("\n".join(lines) + "\n")
 
 def flatten(arg):
       ret = []
@@ -154,5 +153,5 @@ def stripDocString(filepath, eol):
         either.leaveWhitespace()
         out = either.transformString(string)
 
-    with io.open(filepath,'w',newline=eol) as mo_file:
+    with io.open(filepath, 'w', newline=eol) as mo_file:
         mo_file.write(out)

--- a/ttws/cli.py
+++ b/ttws/cli.py
@@ -39,15 +39,12 @@ def main(args=None):
         elif opt in ("-s","--strip"):
             stripOpt = True
         elif opt in ("--eol"):
-            if  arg=="CRLF":
-                print arg
-                eol = "\r\n"
-            elif arg=="LF":
-                eol = "\n"
-            elif arg=="CR":
-                eol = "\r"
-            else:
-                eol = ""
+            eol = {
+                "CRLF": "\r\n",
+                "LF": "\n",
+                "CR": "\r"
+            }
+            eol = eol.get(arg, "")
         else:
             unkownOption(args)
             sys.exit(0)
@@ -107,8 +104,9 @@ def usage(script_name):
                 Force the line endings to be of type:
                  - CRLF = '\\r\\n' Windows
                  - LF = '\\n' POSIX
-                 - CR = '\\r' Mac
-                It defaults on your machine to: %s
+                 - CR = '\\r' Mac (pre OSX)
+                If empty or not specified it is set to the OS default.
+                I.e., on this machine to: %s.
 
             -c, --clean
                 WARNING: USE THIS OPTION AT YOUR OWN RISK AS IT *WILL* BREAK YOUR CODE!
@@ -117,7 +115,7 @@ def usage(script_name):
                 Only use this if your code is under version control
                 and in combination with a careful code-diff review.
 
-        """ % (script_name,extstring, repr(os.linesep))
+        """ % (script_name, extstring, repr(os.linesep))
     print textwrap.dedent(message)
 
 


### PR DESCRIPTION
Makes use of `io.open` instead of standard `open`.
The `io.open` behaviour is actually default in Python 3.
